### PR TITLE
test(e2e) : add Playwright tests for main user flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ La Tulipe este o aplicatie web care permite clientilor sa cumpere flori online, 
 ```
 ┌─────────────┐        ┌─────────────┐        ┌─────────────┐
 │   Frontend  │  HTTP  │   Backend   │  SQL   │  Database   │
-│    React    │◄──────►│Flask (Python│◄──────►│ PostgreSQL  │
-│  Port 3000  │        │  Port 5000  │        │  Port 5432  │
+│    React    │◄──────►│FastAPI (Python)│◄──────►│ PostgreSQL  │
+│  Port 5174  │        │  Port 8000  │        │  Port 5432  │
 └─────────────┘        └─────────────┘        └─────────────┘
 ```
 
 | Layer | Tehnologie |
 |---|---|
-| Frontend | React 18, React Router, Context API |
-| Backend | Python 3.11, Flask, SQLAlchemy |
+| Frontend | React 19, React Router, Context API |
+| Backend | Python 3.11, FastAPI, SQLAlchemy |
 | Baza de date | PostgreSQL 18 |
 | Autentificare | JWT (JSON Web Tokens) + bcrypt |
 | Infrastructure | Docker, Docker Compose |
@@ -77,9 +77,9 @@ docker compose up --build
 ### Acces
 | Serviciu | URL |
 |---|---|
-| Frontend | http://localhost:3000 |
-| Backend API | http://localhost:5000 |
-| Health Check | http://localhost:5000/api/health |
+| Frontend | http://localhost:5174 |
+| Backend API | http://localhost:8000 |
+| Health Check | http://localhost:8000/api/health |
 
 ### Variabile de mediu (.env.example)
 ```
@@ -88,7 +88,7 @@ SECRET_KEY=your-secret-key-here
 JWT_EXPIRY=3600
 DB_USER=postgres
 DB_PASSWORD=postgres
-REACT_APP_API_URL=http://localhost:5000
+REACT_APP_API_URL=http://localhost:8000
 ```
 
 ---
@@ -99,23 +99,32 @@ REACT_APP_API_URL=http://localhost:5000
 La_Tulipe/
 ├── backend/
 │   ├── app/
+│   │   ├── core/            # Configurare bootstrap, securitate
+│   │   ├── database/        # Conexiune DB
 │   │   ├── models/          # Modele SQLAlchemy (User, Product, Order)
-│   │   ├── routes/          # Endpoint-uri Flask (auth, products, orders)
-│   │   ├── middleware/       # JWT auth, admin check
+│   │   ├── routes/          # Endpoint-uri FastAPI (auth, products, orders)
+│   │   ├── middleware/      # JWT auth, admin check
+│   │   ├── schemas/         # Pydantic schemas
+│   │   ├── services/        # Logica business
 │   │   └── __init__.py
 │   ├── tests/               # Teste unitare pytest
 │   ├── Dockerfile
+│   ├── pyproject.toml
 │   └── requirements.txt
 ├── frontend/
 │   ├── src/
 │   │   ├── components/      # Componente reutilizabile (Navbar, Footer, etc.)
 │   │   ├── pages/           # Pagini (Home, Cart, Checkout, Admin)
 │   │   ├── context/         # AuthContext, CartContext
-│   │   └── App.jsx
+│   │   ├── hooks/           # Custom hooks
+│   │   ├── services/        # API calls
+│   │   ├── utils/           # Utility functions
+│   │   ├── dtos/            # Data transfer objects
+│   │   └── App.tsx
+│   ├── tests/               # Teste E2E Playwright
 │   ├── Dockerfile
 │   └── package.json
 ├── features/                # Scenarii BDD Gherkin (.feature)
-├── e2e/                     # Teste E2E Playwright
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml           # Linting + Teste la fiecare PR
@@ -188,15 +197,24 @@ test(orders): add unit tests for order placement
 
 ## 9. Rulare Teste
 
+### 🔹 Teste unitare + integrare (Backend)
+
 ```bash
-# Teste unitare backend
-docker compose exec backend pytest --cov=app tests/
+cd backend/tests
+pytest -q
+```
 
-# Linter backend
-docker compose exec backend ruff check .
+### 🔹 Teste E2E Playwright
 
-# Teste E2E Playwright
-cd e2e && npx playwright test
+```bash
+cd frontend
+npx playwright test
+```
+
+🔹 Raport teste E2E
+
+```bash
+npx playwright show-report
 ```
 
 ---

--- a/frontend/.github/workflows/playwright.yml
+++ b/frontend/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,3 +23,10 @@ dist-ssr
 *.sln
 *.sw?
 .env.local
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,9 +15,10 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@rolldown/plugin-babel": "^0.2.1",
         "@types/babel__core": "^7.20.5",
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -591,6 +592,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.11",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
@@ -955,9 +972,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2583,6 +2600,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,10 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@rolldown/plugin-babel": "^0.2.1",
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5174',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5174',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/tests/admin-orders.spec.ts
+++ b/frontend/tests/admin-orders.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './test-constants';
+
+test('user creates order + admin updates status', async ({ page }) => {
+  const userEmail = `user${Date.now()}@test.com`;
+  const adminEmail = `admin${Date.now()}@test.com`;
+
+
+  await page.goto('/register');
+  await page.fill('#reg-name', TEST_USER.name);
+  await page.fill('#reg-email', userEmail);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/register') && res.status() === 201),
+    page.click('button[type="submit"]'),
+  ]);
+
+
+  await page.goto('/login');
+  await page.fill('#login-email', userEmail);
+  await page.fill('#login-password', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/login') && res.status() === 200),
+    page.click('button[type="submit"]'),
+  ]);
+
+  await page.waitForURL('/');
+
+
+  await page.goto('/');
+
+  const product = page.locator('article').first();
+  await expect(product).toBeVisible();
+
+  await product.click();
+
+  await page.waitForURL(/\/products\/\d+/);
+
+  const addBtn = page.getByRole('button', { name: /(add|select a color first|choose color)/i }).first();
+  await expect(addBtn).toBeVisible();
+  const addBtnText = await addBtn.innerText();
+
+  if (/select a color first|choose color/i.test(addBtnText)) {
+    const colorBtn = page.locator('button[title]:not([disabled])').first();
+    await expect(colorBtn).toBeVisible();
+    await colorBtn.click();
+    const addToCartBtn = page.getByRole('button', { name: /add/i }).first();
+    await expect(addToCartBtn).toBeVisible();
+    await addToCartBtn.click();
+  } else {
+    await addBtn.click();
+  }
+
+
+  await page.goto('/cart');
+  await expect(page.getByRole('heading', { name: 'Your cart' })).toBeVisible();
+  await page.getByRole('button', { name: /place order/i }).click();
+
+  await expect(page.getByPlaceholder('e.g. Ana Popescu')).toBeVisible();
+
+  await page.getByPlaceholder('e.g. Ana Popescu').fill(TEST_USER.name);
+  await page.getByPlaceholder('e.g. ana@example.com').fill(userEmail);
+  await page.getByPlaceholder('e.g. 0721 000 000').fill(TEST_USER.phone);
+  await page.getByPlaceholder('Street, city, postal code').fill('Test Address');
+
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/orders') && res.status() === 201),
+    page.getByRole('button', { name: /place order/i }).click(),
+  ]);
+
+  await expect(page.getByRole('heading', { name: /order placed/i })).toBeVisible();
+
+
+  await page.goto('/register');
+  await page.fill('#reg-name', 'Admin Test');
+  await page.fill('#reg-email', adminEmail);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+  await page.selectOption('select[name="role"]', 'admin');
+  await page.fill('input[name="admin_code"]', TEST_USER.adminCode);
+
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/register') && res.status() === 201),
+    page.click('button[type="submit"]'),
+  ]);
+
+  await page.goto('/login');
+  await page.fill('#login-email', adminEmail);
+  await page.fill('#login-password', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/login') && res.status() === 200),
+    page.click('button[type="submit"]'),
+  ]);
+
+  await page.waitForURL(/\/admin/);
+
+  await page.goto('/admin/orders');
+
+  await expect(page.locator('text=Order Management')).toBeVisible();
+
+ 
+  const firstSelect = page.locator('select').first();
+  await expect(firstSelect).toBeVisible();
+
+  await firstSelect.selectOption('confirmed');
+
+  await expect(firstSelect).toHaveValue('confirmed');
+});

--- a/frontend/tests/auth.spec.ts
+++ b/frontend/tests/auth.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './test-constants';
+
+test('register + login flow', async ({ page }) => {
+  const email = `test${Date.now()}@test.com`;
+
+  await page.goto('/register');
+
+  await page.fill('#reg-name', TEST_USER.name);
+  await page.fill('#reg-email', email);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/register') && res.status() === 201
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+  await page.goto('/login');
+
+  await page.fill('#login-email', email);
+  await page.fill('#login-password', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/login') && res.status() === 200
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+  await expect(page).toHaveURL('/');
+});

--- a/frontend/tests/bouquet.spec.ts
+++ b/frontend/tests/bouquet.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './test-constants';
+
+test('build bouquet and add to cart', async ({ page }) => {
+  const email = `test${Date.now()}@test.com`;
+
+  await page.goto('/register');
+  await page.fill('#reg-name', TEST_USER.name);
+  await page.fill('#reg-email', email);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/register') && res.status() === 201
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+  await page.goto('/login');
+  await page.fill('#login-email', email);
+  await page.fill('#login-password', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/login') && res.status() === 200
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+  await page.goto('/bouquet');
+
+  await expect(page.locator('text=Custom Bouquet Builder')).toBeVisible();
+
+  await page.waitForSelector('button:has-text("+")', { timeout: 10000 });
+
+  const plusBtn = page.locator('button:has-text("+")').first();
+  await expect(plusBtn).toBeVisible();
+  await plusBtn.click();
+
+  const addBouquetBtn = page.getByRole('button', { name: /add bouquet to cart/i });
+  await expect(addBouquetBtn).toBeVisible();
+  await addBouquetBtn.click();
+
+  await page.waitForURL('**/cart');
+
+  await expect(page.locator('p', { hasText: /^Bouquet:/ })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Your cart' })).toBeVisible();
+});

--- a/frontend/tests/checkout.spec.ts
+++ b/frontend/tests/checkout.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './test-constants';
+
+test('complete checkout flow', async ({ page }) => {
+  const email = `test${Date.now()}@test.com`;
+
+  await page.goto('/register');
+  await page.fill('#reg-name', TEST_USER.name);
+  await page.fill('#reg-email', email);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/register') && res.status() === 201
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+
+  await page.goto('/login');
+  await page.fill('#login-email', email);
+  await page.fill('#login-password', TEST_USER.password);
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/auth/login') && res.status() === 200
+    ),
+    page.click('button[type="submit"]')
+  ]);
+
+
+  await page.waitForURL('/');
+  await expect(page.locator('article').first()).toBeVisible();
+
+  const addBtn = page.locator('button:has-text("Add")').first();
+  await expect(addBtn).toBeVisible();
+  await addBtn.click();
+
+  await page.goto('/cart');
+  await expect(page.locator('text=Your cart')).toBeVisible();
+
+  await page.goto('/checkout');
+
+  await expect(page.getByPlaceholder('e.g. Ana Popescu')).toBeVisible();
+
+  await page.getByPlaceholder('e.g. Ana Popescu').fill(TEST_USER.name);
+  await page.getByPlaceholder('e.g. ana@example.com').fill(email);
+  await page.getByPlaceholder('e.g. 0721 000 000').fill(TEST_USER.phone);
+  await page.getByPlaceholder('Street, city, postal code').fill('Strada Test 123');
+
+  await Promise.all([
+    page.waitForResponse(res =>
+      res.url().includes('/api/orders') && res.status() === 201
+    ),
+    page.getByRole('button', { name: /place order/i }).click()
+  ]);
+
+  await expect(page.locator('text=Order placed')).toBeVisible();
+});

--- a/frontend/tests/products.spec.ts
+++ b/frontend/tests/products.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER } from './test-constants';
+
+test('search + add to cart', async ({ page }) => {
+  const email = `test${Date.now()}@test.com`;
+
+  await page.goto('/register');
+  await page.fill('#reg-name', TEST_USER.name);
+  await page.fill('#reg-email', email);
+  await page.fill('#reg-password', TEST_USER.password);
+  await page.fill('#reg-confirm', TEST_USER.password);
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/register') && res.status() === 201),
+    page.click('button[type="submit"]'),
+  ]);
+
+  await page.goto('/login');
+  await page.fill('#login-email', email);
+  await page.fill('#login-password', TEST_USER.password);
+  await Promise.all([
+    page.waitForResponse(res => res.url().includes('/api/auth/login') && res.status() === 200),
+    page.click('button[type="submit"]'),
+  ]);
+  await page.waitForURL('/');
+
+  const products = page.locator('[class*=card]');
+  await expect(products.first()).toBeVisible();
+
+  const searchInput = page.locator('input[type="search"]');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill('rose');
+
+  await page.waitForTimeout(1000);
+
+  await products.first().click();
+
+const chooseBtn = page.getByRole('button', { name: /choose/i });
+
+if (await chooseBtn.isVisible()) {
+  await chooseBtn.click();
+
+  const colorBtn = page.locator('[class*=colorBtn]').first();
+  await colorBtn.click();
+}
+
+const addBtn = page.getByRole('button', { name: /add/i }).first();
+
+await expect(addBtn).toBeVisible();
+await page.waitForTimeout(100);
+await addBtn.click();
+
+await expect(page.locator('div').filter({ hasText: /^✓ Added to cart!$/ })).toBeVisible();
+});

--- a/frontend/tests/test-constants.ts
+++ b/frontend/tests/test-constants.ts
@@ -1,0 +1,7 @@
+export const TEST_USER = {
+  name: 'Test User',
+  email: 'test@example.com',
+  password: '12345678',
+  phone: '0712345678',
+  adminCode: 'secret123',
+} as const;

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
Added 5 E2E tests using Playwright covering main user flows:
- register + login
- search + add to cart
- checkout flow
- bouquet builder
- admin order status update

Tests run successfully locally.